### PR TITLE
[Game] -update: gm commands, position, move, around (#94)

### DIFF
--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -29,7 +29,9 @@
     
     <ItemGroup>
         <Compile Remove="Scripts\**\**" />
-        <Compile Include="Scripts\Commands\HouseBindingMove.cs" />
+        <Compile Include="Scripts\Commands\HouseBindingMove.cs">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
         <None Include="Scripts\**\**" CopyToOutputDirectory="PreserveNewest" LinkBase="Scripts\" />
         <None Include="Data\**\**" CopyToOutputDirectory="PreserveNewest" LinkBase="Data\" />
     </ItemGroup>

--- a/AAEmu.Game/AccessLevels.json
+++ b/AAEmu.Game/AccessLevels.json
@@ -1,4 +1,5 @@
 {
-"teleport":100,
-"fly":0
+    "teleport": 100,
+    "snow": 100,
+    "fly": 0
 }

--- a/AAEmu.Game/Core/Managers/CommandManager.cs
+++ b/AAEmu.Game/Core/Managers/CommandManager.cs
@@ -68,12 +68,6 @@ namespace AAEmu.Game.Core.Managers
             var words = text.Split(' ');
             var thisCommand = words[0].ToLower();
 
-            if(AccessLevel.getLevel(thisCommand) > character.AccessLevel)
-            {
-                character.SendMessage("Insufficient privileges.");
-                return false;
-            }
-
             // Only enable the force_scripts_reload when we don't have anything loaded, this is simply a failsafe function in case
             // things aren't working out when live-editing scripts
             if ((thisCommand == "force_scripts_reload") && (_commands.Count <= 0))
@@ -84,7 +78,7 @@ namespace AAEmu.Game.Core.Managers
 
             if (_commands.Count <= 0)
             {
-                character.SendMessage("[Error] No commands have been loaded, this is usually because of compile errors. Try using " + CommandManager.CommandPrefix + "force_scripts_reload");
+                character.SendMessage("[Error] No commands have been loaded, this is usually because of compile errors. Try using " + CommandManager.CommandPrefix + "force_scripts_reload after the issues have been fixed.");
                 return false;
             }
 
@@ -93,11 +87,20 @@ namespace AAEmu.Game.Core.Managers
             {
                 _commandAliases.TryGetValue(thisCommand, out var alias);
                 if ((alias != null) && (alias != string.Empty))
+                {
                     _commands.TryGetValue(alias, out command);
+                    thisCommand = alias;
+                }
             }
 
             if (command == null)
                 return false;
+
+            if (AccessLevel.getLevel(thisCommand) > character.AccessLevel)
+            {
+                character.SendMessage("|cFFFF0000Insufficient privileges.|r");
+                return true;
+            }
 
             var args = new string[words.Length - 1];
             if (words.Length > 1)

--- a/AAEmu.Game/Scripts/Commands/Move.cs
+++ b/AAEmu.Game/Scripts/Commands/Move.cs
@@ -20,29 +20,78 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "<x> <y> <z>";
+            return "(target) [<x> <y> <z>||ToMe]";
         }
 
         public string GetCommandHelpText()
         {
-            return "Move to target position at <x> <y> <z>";
+            return "Move yourself or (target) player to position <x> <y> <z>.\n" +
+                "You can also use \"ToMe\" instead of coordinates to teleport (target) to your location.\n" +
+                "Or you can only specify a target player to move to that player.\n" +
+                "Examples:\n" +
+                CommandManager.CommandPrefix + "move 21000 12500 200\n" +
+                CommandManager.CommandPrefix + "move TargetPlayer 21000 12500 200\n" +
+                CommandManager.CommandPrefix + "move TargetPlayer ToMe\n" +
+                CommandManager.CommandPrefix + "move TargetPlayer";
         }
 
         public void Execute(Character character, string[] args)
         {
-            if (args.Length < 2)
+            Character targetPlayer = character;
+            var firstarg = 0;
+            if (args.Length > 0)
+                targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstarg);
+
+            var MoveToMe = false;
+
+            if ((targetPlayer != character) && (args.Length == 2) && (args[1].ToLower() == "tome"))
             {
-                character.SendMessage("[Move] " + CommandManager.CommandPrefix + "move <x> <y> <z>");
+                MoveToMe = true;
+            }
+
+            if ((!MoveToMe) && (args.Length < firstarg+3) && (targetPlayer == character))
+            {
+                character.SendMessage("[Move] " + CommandManager.CommandPrefix + "move " + GetCommandLineHelp());
                 return;
             }
 
-            var newX = float.Parse(args[0]);
-            var newY = float.Parse(args[1]);
-            var newZ = float.Parse(args[2]);
+            if (MoveToMe)
+            {
+                var myX = character.Position.X;
+                var myY = character.Position.Y;
+                var myZ = character.Position.Z + 2f; // drop them slightly above you to avoid weird collision stuff
+                if (targetPlayer != character)
+                    targetPlayer.SendMessage("[Move] GM |cFFFFFFFF{0}|r has called upon your presence !", character.Name);
+                targetPlayer.DisabledSetPosition = true;
+                targetPlayer.SendPacket(new SCTeleportUnitPacket(0, 0, myX, myY, myZ, 0f));
+                character.SendMessage("[Move] Moved |cFFFFFFFF{0}|r to your location.", targetPlayer.Name);
+                return;
+            }
+            
+            if ((args.Length == firstarg) && (targetPlayer != character))
+            {
+                var targetX = targetPlayer.Position.X;
+                var targetY = targetPlayer.Position.Y;
+                var targetZ = targetPlayer.Position.Z + 2f; // drop me slightly above them to avoid weird collision stuff
+                character.DisabledSetPosition = true;
+                character.SendPacket(new SCTeleportUnitPacket(0, 0, targetX, targetY, targetZ, 0f));
+                character.SendMessage("[Move] Moved to |cFFFFFFFF{0}|r.", targetPlayer.Name);
+                return;
+            }
 
-            character.DisabledSetPosition = true;
-            character.SendPacket(new SCTeleportUnitPacket(0, 0, newX, newY, newZ, 0f));
-            character.SendMessage("[Move] X: {0}, Y: {1}, Z: {2}", newX, newY, newZ);
+            if ((args.Length == firstarg + 3) && float.TryParse(args[firstarg + 0], out var newX) && float.TryParse(args[firstarg + 1], out var newY) && float.TryParse(args[firstarg + 2], out var newZ))
+            {
+                if (targetPlayer != character)
+                    targetPlayer.SendMessage("[Move] GM |cFFFFFFFF{0}|r has moved you do position X: {1}, Y: {2}, Z: {3}", character.Name, newX, newY, newZ);
+                targetPlayer.DisabledSetPosition = true;
+                targetPlayer.SendPacket(new SCTeleportUnitPacket(0, 0, newX, newY, newZ, 0f));
+                character.SendMessage("[Move] |cFFFFFFFF{0}|r moved to X: {1}, Y: {2}, Z: {3}", targetPlayer.Name, newX, newY, newZ);
+            }
+            else
+            {
+                character.SendMessage("|cFFFF0000[Move] Position parse error|r");
+            }
+
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Position.cs
+++ b/AAEmu.Game/Scripts/Commands/Position.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -14,31 +15,37 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "[rot]";
+            return "(player)";
         }
 
         public string GetCommandHelpText()
         {
-            return "Displays information about your and the position of your target if selected.\n" +
-                "If a argument is set, your rotation information will also be displayed.";
+            return "Displays information about the position of you, or your target if a target is selected or provided as a argument.";
         }
 
         public void Execute(Character character, string[] args)
         {
-            var position = character.CurrentTarget?.Position ?? character.Position;
-            character.SendMessage("[Position] X: {0}, Y: {1}, Z: {2}, ZoneId: {3}", position.X, position.Y, position.Z,
-                position.ZoneId);
-
+            Character targetPlayer = character;
             if (args.Length > 0)
-                character.SendMessage("[Position] RotX: {0}, RotY: {1}, RotZ: {2}", position.RotationX,
-                    position.RotationY,
-                    position.RotationZ);
+                targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstarg);
 
-            if (character.CurrentTarget != null)
+
+            var pos = targetPlayer.Position ;
+
+            var zonename = "???";
+            var zone = ZoneManager.Instance.GetZoneByKey(pos.ZoneId);
+            if (zone != null)
+                zonename = "@ZONE_NAME("+zone.Id.ToString()+")";
+
+            character.SendMessage("[Position] |cFFFFFFFF{0}|r X: |cFFFFFFFF{1:F1}|r  Y: |cFFFFFFFF{2:F1}|r  Z: |cFFFFFFFF{3:F1}|r  RotZ: |cFFFFFFFF{4:F0}|r  ZoneId: |cFFFFFFFF{5}|r {6}",
+                targetPlayer.Name,pos.X, pos.Y, pos.Z, pos.RotationZ, pos.ZoneId, zonename);
+
+            if ((targetPlayer != null) && (targetPlayer != character))
             {
-                var rx = character.Position.X - character.CurrentTarget.Position.X;
-                var ry = character.Position.Y - character.CurrentTarget.Position.Y;
-                character.SendMessage("[Position][Relative] X: {0}, Y: {1}", rx, ry);
+                var rx = character.Position.X - targetPlayer.Position.X;
+                var ry = character.Position.Y - targetPlayer.Position.Y;
+                var rz = character.Position.Z - targetPlayer.Position.Z;
+                character.SendMessage("[Position] |cFF808080[Relative]|r X: |cFFFFFFFF{0:F1}|r  Y: |cFFFFFFFF{1:F1}|r  Z: |cFFFFFFFF{2:F1}|r", rx, ry, rz);
             }
         }
     }

--- a/AAEmu.Game/Scripts/Commands/TestEcho.cs
+++ b/AAEmu.Game/Scripts/Commands/TestEcho.cs
@@ -29,8 +29,8 @@ namespace AAEmu.Game.Scripts.Commands
         {
             string s = string.Empty;
             foreach (string a in args)
-                s += a + " ";
-            character.SendMessage("|cFFFFFFFF[Echo] |r" + s);
+                s = s + a + " ";
+            character.SendMessage("|cFFFFFFFF[Echo]|r " + s);
         }
     }
 }


### PR DESCRIPTION
* [Game] -add: marking deleted characters as deleted

Added code to set the deleted flag in the characters table.
This will not actually delete the character, but will prevent it from showing up.
Possibly needs more updates on other queries like friendslists, guilds, housing, ect.

* [Game] -fix: gm-command alias access level

Moved the access level check so that it works with gm-command aliases as intended.
Added access level 100 to /snow

* [Game] -update: gm commands, position, move, around

Updated various gm commands;
/around
- made radius optional (default 30)
- added object type aliases, pc, player, mob
- now also displays the name of the listed objects
- no longer has a string-size limit that made it so long lists didn't display anything

/position
- removed the [rot] argument, rotation is always displayed now
- added option argument playername to get target player's info
- Now also displays the zone name

/move
- move can now also be used on a target player
- move on a target player without a position will teleport you to that player
- if you specify "ToMe" with a target player instead of a position, that player will be teleported to you