### PR TITLE
Starting rotation is wrong #178 (#179)

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -366,7 +366,11 @@ namespace AAEmu.Game.Core.Managers.UnitManagers
                     point.ZoneId = WorldManager
                         .Instance
                         .GetZoneId(charTemplate.Pos.WorldId, charTemplate.Pos.X, charTemplate.Pos.Y); // TODO ...
-
+                    
+                    point.RotationX = charTemplate.Pos.RotationX;
+                    point.RotationY = charTemplate.Pos.RotationY;
+                    point.RotationZ = charTemplate.Pos.RotationZ;
+                    
                     var template = _templates[(byte)(16 + charTemplate.Id)];
                     template.Position = point;
                     template.NumInventorySlot = charTemplate.NumInventorySlot;

--- a/AAEmu.Game/Data/CharTemplates.json
+++ b/AAEmu.Game/Data/CharTemplates.json
@@ -6,7 +6,10 @@
             "WorldId": 1,
             "X": 15578.042,
             "Y": 15382.122,
-            "Z": 126.484
+            "Z": 126.484,
+			"RotationX": 0,
+			"RotationY": 0,
+			"RotationZ": 53
         },
         "NumInventorySlot": 50,
         "NumBankSlot": 50
@@ -18,7 +21,10 @@
             "WorldId": 1,
             "X": 10388.576,
             "Y": 15982.466,
-            "Z": 367.606
+            "Z": 367.606,
+			"RotationX": 0,
+			"RotationY": 0,
+			"RotationZ": 12
         },
         "NumInventorySlot": 50,
         "NumBankSlot": 50
@@ -30,7 +36,10 @@
             "WorldId": 1,
             "X": 19304.874,
             "Y": 7646.06,
-            "Z": 212.704
+            "Z": 212.704,
+			"RotationX": 0,
+			"RotationY": 0,
+			"RotationZ": 76
         },
         "NumInventorySlot": 50,
         "NumBankSlot": 50
@@ -42,7 +51,10 @@
             "WorldId": 1,
             "X": 23881.218,
             "Y": 10495.782,
-            "Z": 589.7838
+            "Z": 589.7838,
+			"RotationX": 0,
+			"RotationY": 0,
+			"RotationZ": 67
         },
         "NumInventorySlot": 50,
         "NumBankSlot": 50

--- a/AAEmu.Game/Models/Game/Char/Templates/CharacterTemplate.cs
+++ b/AAEmu.Game/Models/Game/Char/Templates/CharacterTemplate.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Models.Game.Char.Templates

--- a/AAEmu.Game/Models/Game/Char/Templates/CharacterTemplateConfig.cs
+++ b/AAEmu.Game/Models/Game/Char/Templates/CharacterTemplateConfig.cs
@@ -1,4 +1,4 @@
-namespace AAEmu.Game.Models.Game.Char.Templates
+﻿namespace AAEmu.Game.Models.Game.Char.Templates
 {
     public class CharacterTemplateConfig
     {
@@ -8,6 +8,10 @@ namespace AAEmu.Game.Models.Game.Char.Templates
             public float X { get; set; }
             public float Y { get; set; }
             public float Z { get; set; }
+            public sbyte RotationX { get; set; }
+            public sbyte RotationY { get; set; }
+            public sbyte RotationZ { get; set; }
+
         }
 
         public uint Id { get; set; }


### PR DESCRIPTION
- added rotations to the characterjson
- added rotations to the model and the manager
- set defaults for the 4 races so they face towards the quest.
- verified it only affects newly created accounts.
- doesn't crash is using the old json without the rotations, uses a
  default of 0.